### PR TITLE
npm scriptsをMakefileに移植

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 2-Clause License
 
-Copyright (c) 2022, Jumpaku
+Copyright (c) 2022, Jumpaku, chu-ta
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
+.DEFAULT_GOAL := help
+
 .PHONY: build
-build:
+build: ## build all scripts
 	make clean && make build_js
 
 .PHONY: build
@@ -22,11 +24,17 @@ build_js_compile:
 build_js_bundle:
 	rollup --sourcemap --format umd --file dist/index.bundle.js dist/js/index.js
 
-
 .PHONY: start
-start:
+start: ## run server
 	node dist/index.bundle.js
 
 .PHONY: test
-test: 
+test: ## run test
 	echo 'test not implemented'
+
+.PHONY: help
+help: ## show this help
+	@echo 'Usage: make [target]'
+	@echo ''
+	@echo 'Targets:'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+.PHONY: build
+build:
+	make clean && make build_js
+
+.PHONY: build
+clean:
+	rm -rf ./dist/*
+
+.PHONY: build_js
+build_js:
+	make build_ts_lint && make build_js_compile && make build_js_bundle
+
+.PHONY: build_ts_lint
+build_ts_lint:
+	eslint --fix src/ts/**/*.ts
+
+.PHONY: build_js_compile
+build_js_compile:
+	tsc
+
+.PHONY: build_js_bundle
+build_js_bundle:
+	rollup --sourcemap --format umd --file dist/index.bundle.js dist/js/index.js
+
+
+.PHONY: start
+start:
+	node dist/index.bundle.js
+
+.PHONY: test
+test: 
+	echo 'test not implemented'

--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ docker compose exec dev bash -c 'npm install'
 
 ```sh
 docker compose up -d
-docker compose exec dev bash -c 'npm run build'
+docker compose exec dev bash -c 'make build'
 ```
 
 ### 起動
 
 ```sh
 docker compose up -d
-docker compose exec dev bash -c 'npm run start'
+docker compose exec dev bash -c 'make start'
 ```

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git+https://github.com/Jumpaku/playing-cards.git"
   },
-  "author": "Jumpaku, ",
+  "author": "Jumpaku, chu-ta, ",
   "license": "BSD-2-Clause",
   "bugs": {
     "url": "https://github.com/Jumpaku/playing-cards/issues"

--- a/package.json
+++ b/package.json
@@ -2,16 +2,6 @@
   "name": "app",
   "version": "1.0.0",
   "description": "Web API for developing games using playing cards",
-  "scripts": {
-    "build": "npm run clean && npm run build:js",
-    "clean": "rm -rf ./dist/*",
-    "build:js": "npm run build:ts:lint && npm run build:js:compile && npm run build:js:bundle",
-    "build:ts:lint": "eslint --fix src/ts/**/*.ts",
-    "build:js:compile": "tsc",
-    "build:js:bundle": "rollup --sourcemap --format umd --file dist/index.bundle.js dist/js/index.js",
-    "start": "node dist/index.bundle.js",
-    "test": "echo 'test not implemented'"
-  },
   "main": "index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
一部の環境で`npm run *`が正しく動作しない問題があったため，npm scriptsを廃止して全て`meke *`で実行できるように修正した．

## 変更点
- Makefileを追加
- npm scriptsを全削除

## 動作確認
Makefileの各コマンドを実行し，正しく動作することを確認した．

