### PR TITLE
Feature/jumpaku/multierr

### DIFF
--- a/src/ts/__tests__/lib/errors/multi_err.test.ts
+++ b/src/ts/__tests__/lib/errors/multi_err.test.ts
@@ -1,0 +1,40 @@
+import { Err } from "../../../lib/errors/base_err";
+import { combine, MultiErr, MultiErrInfo } from "../../../lib/errors/multi_err";
+import { wrapErr } from "../../../lib/errors/utils";
+
+class TestErr extends Err {
+  constructor() {
+    super("TestErr", "test message", {});
+  }
+}
+
+describe("combine", () => {
+  it("wraps 1 error", () => {
+    const err = combine("Error");
+    expect(err.name).toStrictEqual("UnknownErr");
+  });
+
+  it("wraps 1 non null error", () => {
+    const err = combine(undefined, "Error", null);
+    expect(err.name).toStrictEqual("UnknownErr");
+  });
+
+  it("returns itself if it is an instance of Err", () => {
+    const err = combine(new TestErr());
+    expect(err.name).toStrictEqual("TestErr");
+  });
+
+  it("returns itself if there is one non null instance of Err", () => {
+    const err = combine(undefined, new TestErr(), null);
+    expect(err.name).toStrictEqual("TestErr");
+  });
+
+  it("combines and wraps multiple non null errors", () => {
+    const err = combine(undefined, "Error1", null, new TestErr());
+    expect(err.name).toStrictEqual("MultiErr");
+    const info: MultiErrInfo = err.getInfo() as any;
+    expect(info.errors.length).toStrictEqual(2);
+    expect(info.errors[0].name).toStrictEqual("UnknownErr");
+    expect(info.errors[1].name).toStrictEqual("TestErr");
+  });
+});

--- a/src/ts/lib/errors/multi_err.ts
+++ b/src/ts/lib/errors/multi_err.ts
@@ -1,0 +1,21 @@
+import { Err } from "./base_err";
+import { wrapErr } from "./utils";
+
+export type MultiErrInfo = { errors: Err[] };
+export class MultiErr extends Err<MultiErrInfo> {
+  constructor(errors: Err[]) {
+    super(
+      "MultiErr",
+      `error messages: [${errors.map((e) => e.chainMessage()).join(", ")}]`,
+      { errors }
+    );
+  }
+}
+
+export function combine(err: unknown, ...errs: unknown[]): Err {
+  const errList = [err, ...errs].filter((e) => e != null);
+  if (errList.length === 1) {
+    return wrapErr(errList[0]);
+  }
+  return new MultiErr(errList.map((e) => wrapErr(e)));
+}


### PR DESCRIPTION
## 変更点

エラーからの復帰で新たにエラーが発生した場合に，複数のエラーを保持できるクラスを追加

## 動作確認

```sh
make check && make test
```